### PR TITLE
Refactor(test): use `setupFilesAfterEnv` of jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,9 @@ module.exports = {
   collectCoverageFrom: [
     'src/**/*.ts'
   ],
+  setupFilesAfterEnv: [
+    './tests/jest-setup.ts'
+  ],
   testMatch: [
     '**/tests/**/*.test.ts'
   ]

--- a/tests/codeBlock/index.test.ts
+++ b/tests/codeBlock/index.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('Code Block', () => {
   it('Simple code block', () => {
     expect(`code:hello.js

--- a/tests/line/blank.test.ts
+++ b/tests/line/blank.test.ts
@@ -1,8 +1,6 @@
 /* global describe it expect */
 /* eslint-disable no-irregular-whitespace */
 
-import '../jest-setup'
-
 describe('blank', () => {
   it('Simple half-space blank', () => {
     expect('[ ]').toEqualWhenParsing([

--- a/tests/line/bullet.test.ts
+++ b/tests/line/bullet.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('bullet', () => {
   it('Single-byte space indent', () => {
     expect(' Single-byte space').toEqualWhenParsing([

--- a/tests/line/code.test.ts
+++ b/tests/line/code.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('code', () => {
   it('Simple code with backquote', () => {
     expect('`Simple code`').toEqualWhenParsing([

--- a/tests/line/decoration.test.ts
+++ b/tests/line/decoration.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 import { BlockComponentType, convertToBlockComponents } from '../../src/block/BlockComponent'
 import { BlockType } from '../../src/block'
 import { LineType } from '../../src/block/Line'

--- a/tests/line/formula.test.ts
+++ b/tests/line/formula.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('formula', () => {
   it('Simple formula', () => {
     expect('[$ \\frac{3}{2}^N]').toEqualWhenParsing([

--- a/tests/line/googleMap.test.ts
+++ b/tests/line/googleMap.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('googleMap', () => {
   it('Simple google map with NE', () => {
     expect('[N35.6812362,E139.7649361]').toEqualWhenParsing([

--- a/tests/line/hashTag.test.ts
+++ b/tests/line/hashTag.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('hashTag', () => {
   it('Simple hashTag', () => {
     expect('#tag').toEqualWhenParsing([

--- a/tests/line/helpfeel.test.ts
+++ b/tests/line/helpfeel.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('helpfeel', () => {
   it('Simple helpfeel', () => {
     expect('? Simple helpfeel').toEqualWhenParsing([

--- a/tests/line/icon.test.ts
+++ b/tests/line/icon.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('icon', () => {
   it('Simple root icon', () => {
     expect('[/icons/+1.icon]').toEqualWhenParsing([

--- a/tests/line/image.test.ts
+++ b/tests/line/image.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('image', () => {
   it('Simple image', () => {
     expect(`[http://example.com/image.png]

--- a/tests/line/index.test.ts
+++ b/tests/line/index.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('line', () => {
   it('Line that have multi node', () => {
     expect('[Link][Link]').toEqualWhenParsing([

--- a/tests/line/link.test.ts
+++ b/tests/line/link.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('link', () => {
   it('Simple absolute link', () => {
     expect('https://example.com/').toEqualWhenParsing([

--- a/tests/line/plain.test.ts
+++ b/tests/line/plain.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('plain', () => {
   it('Simple plain text', () => {
     expect('Plain text').toEqualWhenParsing([

--- a/tests/line/quote.test.ts
+++ b/tests/line/quote.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('quote', () => {
   it('Simple quote', () => {
     expect('> Simple quote').toEqualWhenParsing([

--- a/tests/line/strong.test.ts
+++ b/tests/line/strong.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('strong', () => {
   it('Simple strong', () => {
     expect('[[Simple strong]]').toEqualWhenParsing([

--- a/tests/line/strongIcon.test.ts
+++ b/tests/line/strongIcon.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('strongIcon', () => {
   it('Simple root strong icon', () => {
     expect('[[/icons/+1.icon]]').toEqualWhenParsing([

--- a/tests/line/strongImage.test.ts
+++ b/tests/line/strongImage.test.ts
@@ -1,7 +1,5 @@
 /* global describe it expect */
 
-import '../jest-setup'
-
 describe('strongImage', () => {
   it('Simple strong image', () => {
     expect(`[[http://example.com/image.png]]

--- a/tests/table/index.test.ts
+++ b/tests/table/index.test.ts
@@ -1,7 +1,6 @@
 /* global describe it expect */
 /* eslint-disable no-tabs, no-irregular-whitespace */
 
-import '../jest-setup'
 import { LineNodeType } from '../../src/block/node'
 
 const defaultTableCells: LineNodeType[][][] = [


### PR DESCRIPTION
## Proposed Changes

- Use [`setupFilesAfterEnv`](https://jestjs.io/docs/en/configuration.html#setupfilesafterenv-array)
- Remove `import '../../jest-setup'` from test files

