### PR TITLE
Feat: add function to get title of page

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { parse, PageType, ParserType } from './parse'
+export { parse, getTitle, PageType, ParserType } from './parse'
 export { BlockType } from './block'
 export { CodeBlockType } from './block/CodeBlock'
 export { TableType } from './block/Table'

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -23,3 +23,9 @@ export const parse: ParserType = input => {
 
   return { title, blocks }
 }
+
+export const getTitle = (input: string): string => {
+  const match = input.match(/^\s*(.*?)\s*\n/)
+  if (!match) return 'Untitled'
+  return match[1] || 'Untiled'
+}

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -25,7 +25,7 @@ export const parse: ParserType = input => {
 }
 
 export const getTitle = (input: string): string => {
-  const match = input.match(/^\s*(.*?)\s*\n/)
+  const match = (`${input}\n`).match(/^\s*(\S[^\n]+)\n/)
   if (!match) return 'Untitled'
-  return match[1] || 'Untiled'
+  return match[1].trim()
 }

--- a/tests/title/index.test.ts
+++ b/tests/title/index.test.ts
@@ -1,0 +1,27 @@
+/* global describe it expect */
+
+import { getTitle } from '../../src/parse'
+
+describe('title', () => {
+  it('Get title from simple page', () => {
+    const title = getTitle('title\nline\nline\n')
+    expect(title).toEqual('title')
+  })
+
+  it('Get title from empty page', () => {
+    expect(getTitle('')).toEqual('Untitled')
+    expect(getTitle(' 　\t')).toEqual('Untitled')
+    expect(getTitle('\n')).toEqual('Untitled')
+    expect(getTitle('\n 　\t')).toEqual('Untitled')
+  })
+
+  it('Get title from title only page', () => {
+    const title = getTitle('title')
+    expect(title).toEqual('title')
+  })
+
+  it('Get title from huge page', () => {
+    const title = getTitle('  \n'.repeat(10**8) + 'title')
+    expect(title).toEqual('title')
+  })
+})


### PR DESCRIPTION
## Proposed Changes

- Add `getTitle` function
  - High performance when parsing huge page

