### PR TITLE
Test: add case for calling API without option

### DIFF
--- a/src/stream/index.ts
+++ b/src/stream/index.ts
@@ -6,7 +6,7 @@ import PackingBlockStream from './PackingBlockStream'
 import ParsingStream from './ParsingStream'
 
 export class ScrapboxParserStream extends CombinedStream {
-  constructor ({ hasTitle = true, ...option }: Partial<ParserOptionType & TransformOptions>) {
+  constructor ({ hasTitle = true, ...option }: Partial<ParserOptionType & TransformOptions> = {}) {
     super(
       option,
       new ConvertToBlockStream(),

--- a/tests/jest-setup.ts
+++ b/tests/jest-setup.ts
@@ -6,18 +6,18 @@ import { toMatchSnapshot } from 'jest-snapshot'
 declare global {
   namespace jest {
     interface Expect {
-      toMatchSnapshotWhenParsing: (received: string, option: ParserOptionType) => CustomMatcherResult
+      toMatchSnapshotWhenParsing: (received: string, option?: Partial<ParserOptionType>) => CustomMatcherResult
     }
 
     interface Matchers<R> {
-      toMatchSnapshotWhenParsing(option: ParserOptionType): CustomMatcherResult
+      toMatchSnapshotWhenParsing(option?: Partial<ParserOptionType>): CustomMatcherResult
     }
   }
 }
 
 expect.extend({
-  toMatchSnapshotWhenParsing (this: any, received: string, { hasTitle }: ParserOptionType): jest.CustomMatcherResult {
-    const blocks = parse(received, { hasTitle })
+  toMatchSnapshotWhenParsing (this: any, received: string, option?: Partial<ParserOptionType>): jest.CustomMatcherResult {
+    const blocks = parse(received, option)
     return toMatchSnapshot.call(this, blocks, 'toMatchSnapshotWhenParsing')
   }
 })

--- a/tests/page/__snapshots__/index.test.ts.snap
+++ b/tests/page/__snapshots__/index.test.ts.snap
@@ -9,6 +9,15 @@ Array [
 ]
 `;
 
+exports[`page Title Block without \`hasTitle\` option: toMatchSnapshotWhenParsing 1`] = `
+Array [
+  Object {
+    "text": "Title",
+    "type": "title",
+  },
+]
+`;
+
 exports[`page https://scrapbox.io/help/Syntax: toMatchSnapshotWhenParsing 1`] = `
 Array [
   Object {

--- a/tests/page/index.test.ts
+++ b/tests/page/index.test.ts
@@ -8,6 +8,11 @@ describe('page', () => {
     expect(input).toMatchSnapshotWhenParsing({ hasTitle: true })
   })
 
+  it('Title Block without `hasTitle` option', () => {
+    const input = 'Title'
+    expect(input).toMatchSnapshotWhenParsing()
+  })
+
   it('https://scrapbox.io/help/Syntax', () => {
     const input = fs.readFileSync('./tests/page/input.txt').toString()
     expect(input).toMatchSnapshotWhenParsing({ hasTitle: true })

--- a/tests/stream/index.test.ts
+++ b/tests/stream/index.test.ts
@@ -6,21 +6,22 @@ import { parse } from '../../src/parse'
 import { BlockType } from '../../src/block'
 import { ScrapboxParserStream } from '../../src/stream'
 
+type CheckFunctionType = (block: BlockType) => void
+
 const FILE_PATH = './tests/stream/body.txt'
 
 class CheckStream extends Transform {
-  answer: BlockType[]
   done: jest.DoneCallback
+  check: CheckFunctionType
 
-  constructor (done: jest.DoneCallback) {
+  constructor (check: CheckFunctionType, done: jest.DoneCallback) {
     super({ objectMode: true })
-    const page = fs.readFileSync(FILE_PATH, { encoding: 'utf8' })
-    this.answer = parse(page, { hasTitle: true })
+    this.check = check
     this.done = done
   }
 
   _transform (block: BlockType, _encoding: string, callback: TransformCallback) {
-    expect(block).toEqual(this.answer.shift())
+    this.check(block)
     callback()
   }
 
@@ -31,9 +32,24 @@ class CheckStream extends Transform {
 }
 
 describe('stream', () => {
-  it('Same behavior ', async (done) => {
+  it('Same behavior', async (done) => {
+    const generateChecker = (): CheckFunctionType => {
+      const page = fs.readFileSync(FILE_PATH, { encoding: 'utf8' })
+      const answer = parse(page, { hasTitle: true })
+      return (block) => {
+        expect(block).toEqual(answer.shift())
+      }
+    }
+
     fs.createReadStream(FILE_PATH, { highWaterMark: 100, encoding: 'utf8' })
-      .pipe(new ScrapboxParserStream({ hasTitle: true }))
-      .pipe(new CheckStream(done))
+      .pipe(new ScrapboxParserStream())
+      .pipe(new CheckStream(generateChecker(), done))
+  })
+
+  it('Title Block without `hasTitle` option', async (done) => {
+    const check: CheckFunctionType = (block) => { expect(block.type).not.toEqual('title') }
+    fs.createReadStream(FILE_PATH, { highWaterMark: 100, encoding: 'utf8' })
+      .pipe(new ScrapboxParserStream({ hasTitle: false }))
+      .pipe(new CheckStream(check, done))
   })
 })


### PR DESCRIPTION
## Proposed Changes

- Add test case to `parse` , `ScrapboxParserStream`
  - Without 2nd argument `option` (optional)

