### PR TITLE
Refactor(types): Rename internal node parser types

### DIFF
--- a/src/block/node/BlankNode.ts
+++ b/src/block/node/BlankNode.ts
@@ -1,4 +1,4 @@
-import { ParserType, convertToLineNodes } from '.'
+import { NodeParserType, convertToLineNodes } from '.'
 
 const blankRegExp = /^(.*?)\[(\s+)\](.*)$/
 
@@ -12,7 +12,7 @@ const createBlankNode = (text: string): BlankNodeType => ({
   text
 })
 
-export const BlankNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const BlankNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   if (nested) return next()
 
   const blankMatch = text.match(blankRegExp)

--- a/src/block/node/CodeNode.ts
+++ b/src/block/node/CodeNode.ts
@@ -1,4 +1,4 @@
-import { ParserType, convertToLineNodes } from '.'
+import { NodeParserType, convertToLineNodes } from '.'
 
 const codeRegExp = /^(.*?)`(.*?)`(.*)$/
 const codeCommandRegExp = /^(\$ .+)$/
@@ -13,7 +13,7 @@ const createCodeNode = (text: string): CodeNodeType => ({
   text
 })
 
-export const CodeNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const CodeNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   if (nested) return next()
 
   const codeCommandMatch = text.match(codeCommandRegExp)

--- a/src/block/node/DecorationNode.ts
+++ b/src/block/node/DecorationNode.ts
@@ -1,4 +1,4 @@
-import { ParserType, LineNodeType, convertToLineNodes } from '.'
+import { NodeParserType, LineNodeType, convertToLineNodes } from '.'
 
 const decorationRegExp = /^(.*?)\[([!"#%&'()*+,-./{|}<>_~]+) ((?:\[[^\]]+\]|[^\]])+)\](.*)$/
 
@@ -26,7 +26,7 @@ const createDecorationNode = (decoChars: string, nodes: LineNodeType[]): Decorat
   }
 }
 
-export const DecorationNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const DecorationNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   if (nested) return next()
 
   const decorationMatch = text.match(decorationRegExp)

--- a/src/block/node/FormulaNode.ts
+++ b/src/block/node/FormulaNode.ts
@@ -1,4 +1,4 @@
-import { ParserType, convertToLineNodes } from '.'
+import { NodeParserType, convertToLineNodes } from '.'
 
 const formulaWithTailHalfSpaceRegExp = /^(.*?)\[\$ (.+?) \](.*)$/
 const formulaRegExp = /^(.*?)\[\$ ([^\]]+)\](.*)$/
@@ -13,7 +13,7 @@ const createFormulaNode = (formula: string): FormulaNodeType => ({
   formula
 })
 
-export const FormulaNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const FormulaNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   if (nested) return next()
 
   const hashTagMatch = text.match(formulaWithTailHalfSpaceRegExp) || text.match(formulaRegExp)

--- a/src/block/node/GoogleMapNode.ts
+++ b/src/block/node/GoogleMapNode.ts
@@ -1,4 +1,4 @@
-import { ParserType, convertToLineNodes } from '.'
+import { NodeParserType, convertToLineNodes } from '.'
 
 const googleMapRegExp = /^(?<left>.*?)\[(?<latitude>([NS]\d+(\.\d+)?),(?<longitude>[EW]\d+(\.\d+)?)(?<zoom>(,Z\d+)?))(?<place>)\](?<right>.*)$/
 const leftGoogleMapRegExp = /^(?<left>.*?)\[(?<place>[^\]]*[^\s])\s+(?<latitude>([NS]\d+(\.\d+)?),(?<longitude>[EW]\d+(\.\d+)?)(?<zoom>(,Z\d+)?))\](?<right>.*)$/
@@ -46,7 +46,7 @@ const createGoogleMapNode = (_latitude: string, _longitude: string, _zoom: strin
   }
 }
 
-export const GoogleMapNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const GoogleMapNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   if (nested) return next()
 
   const googleMapMatch = text.match(googleMapRegExp) ||

--- a/src/block/node/HashTagNode.ts
+++ b/src/block/node/HashTagNode.ts
@@ -1,4 +1,4 @@
-import { ParserType, convertToLineNodes } from '.'
+import { NodeParserType, convertToLineNodes } from '.'
 
 const hashTagRegExp = /^(.*? )?#(\S+)(.*)?$/
 
@@ -12,7 +12,7 @@ const createHashTagNode = (href: string): HashTagNodeType => ({
   href
 })
 
-export const HashTagNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const HashTagNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   if (nested) return next()
 
   const hashTagMatch = text.match(hashTagRegExp)

--- a/src/block/node/HelpfeelNode.ts
+++ b/src/block/node/HelpfeelNode.ts
@@ -1,4 +1,4 @@
-import { ParserType } from '.'
+import { NodeParserType } from '.'
 
 const helpfeelRegExp = /^\? (.+)$/
 
@@ -12,7 +12,7 @@ const createHelpfeelNode = (text: string): HelpfeelNodeType => ({
   text
 })
 
-export const HelpfeelNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const HelpfeelNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   if (nested || quoted) return next()
 
   const helpfeelMatch = text.match(helpfeelRegExp)

--- a/src/block/node/IconNode.ts
+++ b/src/block/node/IconNode.ts
@@ -1,4 +1,4 @@
-import { ParserType, convertToLineNodes } from '.'
+import { NodeParserType, convertToLineNodes } from '.'
 
 const iconRegExp = /^(.*?)\[(.*)\.icon(\*(\d+))?\](.*)$/
 
@@ -14,7 +14,7 @@ const createIconNode = (path: string): IconNodeType | null => ({
   path
 })
 
-export const IconNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const IconNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   if (nested) return next()
 
   const iconMatch = text.match(iconRegExp)

--- a/src/block/node/InternalLinkNode.ts
+++ b/src/block/node/InternalLinkNode.ts
@@ -1,4 +1,4 @@
-import { ParserType, convertToLineNodes } from '.'
+import { NodeParserType, convertToLineNodes } from '.'
 
 const internalLinkRegExp = /^(.*?)\[(\/?[^[\]]+)\](.*)$/
 
@@ -16,7 +16,7 @@ const createInternalLinkNode = (href: string): InternalLinkNodeType => ({
   content: ''
 })
 
-export const InternalLinkNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const InternalLinkNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   const internalLinkMatch = text.match(internalLinkRegExp)
   if (!internalLinkMatch) return next()
 

--- a/src/block/node/QuoteNode.ts
+++ b/src/block/node/QuoteNode.ts
@@ -1,4 +1,4 @@
-import { ParserType, LineNodeType, convertToLineNodes } from '.'
+import { NodeParserType, LineNodeType, convertToLineNodes } from '.'
 
 const quoteRegExp = /^>(.*)$/
 
@@ -12,7 +12,7 @@ const createQuoteNode = (text: string): QuoteNodeType => ({
   nodes: convertToLineNodes(text, { nested: false, quoted: true })
 })
 
-export const QuoteNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const QuoteNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   if (nested || quoted) return next()
   const quoteMatch = text.match(quoteRegExp)
   if (!quoteMatch) return next()

--- a/src/block/node/StrongIconNode.ts
+++ b/src/block/node/StrongIconNode.ts
@@ -1,4 +1,4 @@
-import { ParserType, convertToLineNodes } from '.'
+import { NodeParserType, convertToLineNodes } from '.'
 
 const iconRegExp = /^(.*?)\[\[(.*)\.icon(\*(\d+))?\]\](.*)$/
 
@@ -14,7 +14,7 @@ const createStrongIconNode = (path: string): StrongIconNodeType => ({
   path
 })
 
-export const StrongIconNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const StrongIconNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   if (nested) return next()
 
   const iconMatch = text.match(iconRegExp)

--- a/src/block/node/StrongImageNode.ts
+++ b/src/block/node/StrongImageNode.ts
@@ -1,4 +1,4 @@
-import { ParserType, convertToLineNodes } from '.'
+import { NodeParserType, convertToLineNodes } from '.'
 
 const strongImageRegExp = /^(?<left>.*?)\[\[(?<src>https?:\/\/[^\s\]]+\.(png|jpe?g|gif|svg))\]\](?<right>.*)$/i
 const gyazoStrongImageRegExp = /^(?<left>.*?)\[\[(?<src>https?:\/\/([0-9a-z-]+\.)?gyazo\.com\/[0-9a-f]{32})\]\](?<right>.*)$/
@@ -25,7 +25,7 @@ const createStrongImageNode = (src: string): StrongImageNodeType => ({
   src
 })
 
-export const StrongImageNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const StrongImageNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   if (nested) return next()
 
   const StrongImageMatch = text.match(strongImageRegExp) || text.match(gyazoStrongImageRegExp)

--- a/src/block/node/StrongNode.ts
+++ b/src/block/node/StrongNode.ts
@@ -1,4 +1,4 @@
-import { ParserType, LineNodeType, convertToLineNodes } from '.'
+import { NodeParserType, LineNodeType, convertToLineNodes } from '.'
 
 const strongRegExp = /^(.*?)\[\[(.+?[\]]*)\]\](.*)$/
 
@@ -12,7 +12,7 @@ const createStrongNode = (nodes: LineNodeType[]): StrongNodeType => ({
   nodes
 })
 
-export const StrongNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const StrongNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   if (nested) return next()
 
   const strongMatch = text.match(strongRegExp)

--- a/src/block/node/UrlNode/index.ts
+++ b/src/block/node/UrlNode/index.ts
@@ -1,4 +1,4 @@
-import { ParserType, convertToLineNodes } from '../'
+import { NodeParserType, convertToLineNodes } from '../'
 import { ExternalLinkNodeType, createExternalLinkNode } from './ExternalLinkNode'
 import { ImageNodeType, createImageNode } from './ImageNode'
 
@@ -40,7 +40,7 @@ const createUrlNode = (href: string, content: string): UrlNodeType => {
   return createImageNode(href, content)
 }
 
-export const UrlNodeParser: ParserType = (text, { nested, quoted }, next) => {
+export const UrlNodeParser: NodeParserType = (text, { nested, quoted }, next) => {
   const UrlMatch = text.match(urlRegExp) ||
                    text.match(leftUrlRegExp) ||
                    text.match(rightUrlRegExp) ||

--- a/src/block/node/index.ts
+++ b/src/block/node/index.ts
@@ -30,22 +30,22 @@ export type LineNodeType = QuoteNodeType
                          | HashTagNodeType
                          | PlainNodeType
 
-export type ParserOptionType = {
+export type NodeParserOptionType = {
   nested: boolean
   quoted: boolean
 }
-export type NextParserType = () => LineNodeType[]
-export type ParserType = (text: string, opt: ParserOptionType, next: NextParserType) => LineNodeType[]
+export type NextNodeParserType = () => LineNodeType[]
+export type NodeParserType = (text: string, opt: NodeParserOptionType, next: NextNodeParserType) => LineNodeType[]
 
-const FalsyEliminator: ParserType = (text, _opt, next) => {
+const FalsyEliminator: NodeParserType = (text, _opt, next) => {
   if (!text) return []
   return next()
 }
 
-const combineNodeParsers = (...parsers: ParserType[]) => {
-  return (text: string = '', opt: ParserOptionType = { nested: false, quoted: false }): LineNodeType[] => (
+const combineNodeParsers = (...parsers: NodeParserType[]) => {
+  return (text: string = '', opt: NodeParserOptionType = { nested: false, quoted: false }): LineNodeType[] => (
     parsers.slice().reverse().reduce(
-      (acc: NextParserType, parser: ParserType): NextParserType => () => parser(text, opt, acc),
+      (acc: NextNodeParserType, parser: NodeParserType): NextNodeParserType => () => parser(text, opt, acc),
       () => PlainNodeParser(text)
     )()
   )


### PR DESCRIPTION
## Proposed Changes

- In development, `ParserOptionType` is conflict.
	- `/src/parse.ts` (global parser)
	- `/src/block/node/index.ts` (internal node parser)
- To resolve the conflict, rename internal node parser types
