### PR TITLE
Feat(tsconfig): set `tsBuildInfoFile` options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 lib
 esm
 umd
+*.tsbuildinfo
 
 ### https://raw.github.com/github/gitignore/4a8e0a151becd5ccbb83e4aca6e6c195f3d506fd/Global/macOS.gitignore
 

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "module": "commonjs",
     "outDir": "./lib",
+    "tsBuildInfoFile": "./.cjs.tsbuildinfo",
     }
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -3,5 +3,6 @@
   "compilerOptions": {
     "module": "es2015",
     "outDir": "./esm",
+    "tsBuildInfoFile": "./.esm.tsbuildinfo",
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./lib",                     /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
+    "composite": true,                        /* Enable project compilation */
+    // "tsBuildInfoFile": "./.tsbuildinfo",   /* Specify file to store incremental compilation information *
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */

--- a/tsconfig.umd.json
+++ b/tsconfig.umd.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "ESNext",
     "outDir": "./umd",
+    "composite": false,
     "declaration": false,
     "declarationMap": false
   }


### PR DESCRIPTION
## Proposed Changes

- Set `tsBuildInfoFile` option to tsconfig files for building.


## Performances

### Without `tsBuildInfoFile`

```sh
npm run build  22.46s user 2.13s system 124% cpu 19.777 total
```

### With `tsBuildInfoFile`

```sh
npm run build  11.41s user 1.17s system 138% cpu 9.085 total
```