### PR TITLE
Chore: use standard-with-typescript for lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,10 @@ module.exports = {
     'browser': true,
     'es6': true
   },
-  'extends': 'standard',
+  'extends': [
+    'standard',
+    'standard-with-typescript'
+  ],
   'globals': {
     'Atomics': 'readonly',
     'SharedArrayBuffer': 'readonly'
@@ -20,6 +23,15 @@ module.exports = {
     'jest'
   ],
   'rules': {
-    '@typescript-eslint/no-unused-vars': [2, { args: 'none' }]
+    '@typescript-eslint/consistent-type-assertions': 'off',
+    '@typescript-eslint/consistent-type-definitions': 'off',
+    '@typescript-eslint/indent': 'off',
+    '@typescript-eslint/method-signature-style': 'off',
+    '@typescript-eslint/member-delimiter-style': 'off',
+    '@typescript-eslint/no-namespace': 'off',
+    '@typescript-eslint/no-unused-vars': [2, { args: 'none' }],
+    '@typescript-eslint/prefer-nullish-coalescing': 'off',
+    '@typescript-eslint/prefer-optional-chain': 'off',
+    '@typescript-eslint/strict-boolean-expressions': 'off'
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6510,6 +6510,16 @@
       "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
       "dev": true
     },
+    "eslint-config-standard-with-typescript": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard-with-typescript/-/eslint-config-standard-with-typescript-18.0.2.tgz",
+      "integrity": "sha512-6D++u/gifJgj2hQ13e+YRyNs+1v3oihkfsL36P6HjeQjiOBdhRC/0wq3PRqfOwFA0hMCkcWBvhfO0GXWtGW9bg==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/parser": "^3.0.1",
+        "eslint-config-standard": "^14.1.1"
+      }
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "babel-loader": "8.1.0",
     "eslint": "7.2.0",
     "eslint-config-standard": "14.1.1",
+    "eslint-config-standard-with-typescript": "^18.0.2",
     "eslint-plugin-import": "2.21.2",
     "eslint-plugin-jest": "23.13.2",
     "eslint-plugin-node": "11.1.0",


### PR DESCRIPTION
## Proposed Changes

- Install and setup [`eslint-config-standard-with-typescript`](https://www.npmjs.com/package/eslint-config-standard-with-typescript) .
- Disable the rule that caused error in the current code.
