### PR TITLE
Style: enable rules of standard-with-typescript partially

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,11 +25,7 @@ module.exports = {
   'rules': {
     '@typescript-eslint/consistent-type-assertions': 'off',
     '@typescript-eslint/consistent-type-definitions': 'off',
-    '@typescript-eslint/indent': 'off',
-    '@typescript-eslint/method-signature-style': 'off',
-    '@typescript-eslint/member-delimiter-style': 'off',
     '@typescript-eslint/no-namespace': 'off',
-    '@typescript-eslint/no-unused-vars': [2, { args: 'none' }],
     '@typescript-eslint/prefer-nullish-coalescing': 'off',
     '@typescript-eslint/prefer-optional-chain': 'off',
     '@typescript-eslint/strict-boolean-expressions': 'off'

--- a/src/block/node/InternalLinkNode.ts
+++ b/src/block/node/InternalLinkNode.ts
@@ -7,7 +7,7 @@ const internalLinkRegExp = /^(.*?)\[(\/?[^[\]]+)\](.*)$/
 export type InternalLinkNodeType = {
   type: 'link'
   pathType: 'root' | 'relative'
-  href: string,
+  href: string
   content: string
 }
 

--- a/src/block/node/index.ts
+++ b/src/block/node/index.ts
@@ -30,21 +30,22 @@ import type { IconNodeType } from './IconNode'
 import type { HashTagNodeType } from './HashTagNode'
 import type { PlainNodeType } from './PlainNode'
 
-export type LineNodeType = QuoteNodeType
-                         | HelpfeelNodeType
-                         | StrongImageNodeType
-                         | StrongIconNodeType
-                         | StrongNodeType
-                         | FormulaNodeType
-                         | DecorationNodeType
-                         | CodeNodeType
-                         | BlankNodeType
-                         | UrlNodeType
-                         | GoogleMapNodeType
-                         | InternalLinkNodeType
-                         | IconNodeType
-                         | HashTagNodeType
-                         | PlainNodeType
+export type LineNodeType =
+| QuoteNodeType
+| HelpfeelNodeType
+| StrongImageNodeType
+| StrongIconNodeType
+| StrongNodeType
+| FormulaNodeType
+| DecorationNodeType
+| CodeNodeType
+| BlankNodeType
+| UrlNodeType
+| GoogleMapNodeType
+| InternalLinkNodeType
+| IconNodeType
+| HashTagNodeType
+| PlainNodeType
 
 export type NodeParserOptionType = {
   nested: boolean

--- a/tests/jest-setup.ts
+++ b/tests/jest-setup.ts
@@ -8,7 +8,7 @@ declare global {
     }
 
     interface Matchers<R, T> {
-      toMatchSnapshotWhenParsing(option?: Partial<ParserOptionType>): CustomMatcherResult
+      toMatchSnapshotWhenParsing: (option?: Partial<ParserOptionType>) => CustomMatcherResult
     }
   }
 }


### PR DESCRIPTION
## Proposed Changes

- Enable rules of `standard-with-typescript`
	- `@typescript-eslint/indent`
	- `@typescript-eslint/method-signature-style`
	- `@typescript-eslint/member-delimiter-style`
	- `@typescript-eslint/no-unused-vars`
