### PR TITLE
Style(typescript-eslint): enable no-namespace

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,8 +21,5 @@ module.exports = {
   'plugins': [
     '@typescript-eslint',
     'jest'
-  ],
-  'rules': {
-    '@typescript-eslint/no-namespace': 'off'
-  }
+  ]
 }

--- a/tests/jest-setup.ts
+++ b/tests/jest-setup.ts
@@ -2,6 +2,7 @@ import { parse, ParserOption } from '../src'
 import { toMatchSnapshot } from 'jest-snapshot'
 
 declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace jest {
     interface Expect {
       toMatchSnapshotWhenParsing: (received: string, option?: Partial<ParserOption>) => CustomMatcherResult


### PR DESCRIPTION
## Proposed Changes

- Enable `@typescript-eslint/no-namespace`


## Provisional Treating

- Require `namespace` word for using `CustomMatcher` in jest.
- Allow using `namespace` word only for `jest.expect.extend` .
