### PR TITLE
Fix: different (strong) icon nodes have different reference to Object

### DIFF
--- a/src/block/node/IconNode.ts
+++ b/src/block/node/IconNode.ts
@@ -10,7 +10,7 @@ export interface IconNode {
   path: string
 }
 
-const createIconNode = (path: string): IconNode | null => ({
+const createIconNode = (path: string): IconNode => ({
   type: 'icon',
   pathType: /^\//.test(path) ? 'root' : 'relative',
   path
@@ -23,10 +23,13 @@ export const IconNodeParser: NodeParser = (text, { nested, quoted }, next) => {
   if (iconMatch === null) return next()
 
   const [, left, path, , num = '1', right] = iconMatch
-  const iconNode = createIconNode(path)
+  const iconNodes = new Array(parseInt(num, 10))
+    .fill({})
+    .map(_ => createIconNode(path))
+
   return [
     ...convertToLineNodes(left, { nested, quoted }),
-    ...new Array(parseInt(num, 10)).fill(iconNode),
+    ...iconNodes,
     ...convertToLineNodes(right, { nested, quoted })
   ]
 }

--- a/src/block/node/StrongIconNode.ts
+++ b/src/block/node/StrongIconNode.ts
@@ -27,10 +27,13 @@ export const StrongIconNodeParser: NodeParser = (
   if (iconMatch === null) return next()
 
   const [, left, path, , num = '1', right] = iconMatch
-  const iconNode = createStrongIconNode(path)
+  const iconNodes = new Array(parseInt(num, 10))
+    .fill({})
+    .map(_ => createStrongIconNode(path))
+
   return [
     ...convertToLineNodes(left, { nested, quoted }),
-    ...new Array(parseInt(num, 10)).fill(iconNode),
+    ...iconNodes,
     ...convertToLineNodes(right, { nested, quoted })
   ]
 }

--- a/tests/line/icon.test.ts
+++ b/tests/line/icon.test.ts
@@ -1,3 +1,5 @@
+import { parse } from '../../src'
+
 describe('icon', () => {
   it('Simple root icon', () => {
     expect('[/icons/+1.icon]').toMatchSnapshotWhenParsing({ hasTitle: false })
@@ -13,5 +15,15 @@ describe('icon', () => {
 
   it('Icon and internal link on same line', () => {
     expect('[Internal link][me.icon]').toMatchSnapshotWhenParsing({ hasTitle: false })
+  })
+
+  it('Each multiple icon must be different Object', () => {
+    const [block] = parse('[me.icon*2]', { hasTitle: false })
+    if (block.type !== 'line') {
+      throw new Error('fail')
+    }
+
+    const [icon1, icon2] = block.nodes
+    expect(icon1 === icon2).toBe(false)
   })
 })

--- a/tests/line/strongIcon.test.ts
+++ b/tests/line/strongIcon.test.ts
@@ -1,3 +1,5 @@
+import { parse } from '../../src'
+
 describe('strongIcon', () => {
   it('Simple root strong icon', () => {
     expect('[[/icons/+1.icon]]').toMatchSnapshotWhenParsing({ hasTitle: false })
@@ -13,5 +15,15 @@ describe('strongIcon', () => {
 
   it('Strong icon and internal link on same line', () => {
     expect('[Internal link][[me.icon]]').toMatchSnapshotWhenParsing({ hasTitle: false })
+  })
+
+  it('Each multiple strong icon must be different Object', () => {
+    const [block] = parse('[[me.icon*2]]', { hasTitle: false })
+    if (block.type !== 'line') {
+      throw new Error('fail')
+    }
+
+    const [strongIcon1, strongIcon2] = block.nodes
+    expect(strongIcon1 === strongIcon2).toBe(false)
   })
 })


### PR DESCRIPTION
## Proposed Changes

- `[me.icon*2]` was converted to icon nodes that have same object reference.
- There should have different reference
