### PR TITLE
Refactor: use RegExp.exec for search pattern

### DIFF
--- a/src/block/BlockComponent.ts
+++ b/src/block/BlockComponent.ts
@@ -4,7 +4,7 @@ export interface BlockComponent {
 }
 
 export const convertToBlockComponent = (block: string): BlockComponent => ({
-  indent: block.match(/^\s+/)?.[0].length ?? 0,
+  indent: /^\s+/.exec(block)?.[0].length ?? 0,
   text: block
 })
 

--- a/src/block/node/BlankNode.ts
+++ b/src/block/node/BlankNode.ts
@@ -2,7 +2,7 @@ import { createNodeParser } from './creator'
 
 import type { NodeCreator } from './creator'
 
-const blankRegExp = /^(.*?)(\[\s+\])(.*)$/
+const blankRegExp = /\[\s+\]/
 
 export interface BlankNode {
   type: 'blank'

--- a/src/block/node/CodeNode.ts
+++ b/src/block/node/CodeNode.ts
@@ -2,7 +2,7 @@ import { createNodeParser } from './creator'
 
 import type { NodeCreator } from './creator'
 
-const codeRegExp = /^(.*?)(`.*?`)(.*)$/
+const codeRegExp = /`.*?`/
 
 export interface CodeNode {
   type: 'code'

--- a/src/block/node/CommandLineNode.ts
+++ b/src/block/node/CommandLineNode.ts
@@ -2,7 +2,7 @@ import { createNodeParser } from './creator'
 
 import type { NodeCreator } from './creator'
 
-const commandLineRegExp = /^()([$%] .+)()$/
+const commandLineRegExp = /^([$%]) (.+)$/
 
 export interface CommandLineNode {
   type: 'commandLine'
@@ -11,7 +11,7 @@ export interface CommandLineNode {
 }
 
 const createCommandLineNode: NodeCreator<CommandLineNode> = (target: string) => {
-  const match = target.match(/^([$%]) (.+)$/)
+  const match = target.match(commandLineRegExp)
   if (match === null) return []
   const [, symbol, text] = match
   return {

--- a/src/block/node/DecorationNode.ts
+++ b/src/block/node/DecorationNode.ts
@@ -3,7 +3,7 @@ import { createNodeParser } from './creator'
 import { convertToLineNodes, LineNode } from '.'
 import type { NodeCreator } from './creator'
 
-const decorationRegExp = /^(.*?)(\[[!"#%&'()*+,-./{|}<>_~]+ (?:\[[^\]]+\]|[^\]])+\])(.*)$/
+const decorationRegExp = /\[[!"#%&'()*+,-./{|}<>_~]+ (?:\[[^\]]+\]|[^\]])+\]/
 
 export type DecorationChar =
   | '*'

--- a/src/block/node/ExternalLinkNode.ts
+++ b/src/block/node/ExternalLinkNode.ts
@@ -2,9 +2,9 @@ import { createNodeParser } from './creator'
 
 import type { NodeCreator } from './creator'
 
-const hrefFirstUrlRegExp = /^(.*?)(\[https?:\/\/[^\s\]]+(?:\s+[^\]]*[^\s])?\])(.*)$/
-const contentFirstUrlRegExp = /^(.*?)(\[[^\]]*[^\s]\s+https?:\/\/[^\s\]]+\])(.*)$/
-const httpRegExp = /^(.*?\s)?(https?:\/\/[^\s\]]+)(.*)$/
+const hrefFirstUrlRegExp = /\[https?:\/\/[^\s\]]+(?:\s+[^\]]*[^\s])?\]/
+const contentFirstUrlRegExp = /\[[^\]]*[^\s]\s+https?:\/\/[^\s\]]+\]/
+const httpRegExp = /(?<=^| )https?:\/\/[^\s\]]+/
 
 export interface ExternalLinkNode {
   type: 'link'

--- a/src/block/node/FormulaNode.ts
+++ b/src/block/node/FormulaNode.ts
@@ -2,8 +2,8 @@ import { createNodeParser } from './creator'
 
 import type { NodeCreator } from './creator'
 
-const formulaWithTailHalfSpaceRegExp = /^(.*?)(\[\$ .+? \])(.*)$/
-const formulaRegExp = /^(.*?)(\[\$ [^\]]+\])(.*)$/
+const formulaWithTailHalfSpaceRegExp = /\[\$ .+? \]/
+const formulaRegExp = /\[\$ [^\]]+\]/
 
 export interface FormulaNode {
   type: 'formula'

--- a/src/block/node/GoogleMapNode.ts
+++ b/src/block/node/GoogleMapNode.ts
@@ -2,8 +2,8 @@ import { createNodeParser } from './creator'
 
 import type { NodeCreator } from './creator'
 
-const placeFirstGoogleMapRegExp = /^(.*?)(\[(?:[^\]]*[^\s]\s+)?[NS]\d+(?:\.\d+)?,[EW]\d+(?:\.\d+)?(?:,Z\d+)?\])(.*)$/
-const coordFirstGoogleMapRegExp = /^(.*?)(\[[NS]\d+(?:\.\d+)?,[EW]\d+(?:\.\d+)?(?:,Z\d+)?(?:\s+[^\]]*[^\s])?\])(.*)$/
+const placeFirstGoogleMapRegExp = /\[([^\]]*[^\s])\s+([NS]\d+(?:\.\d+)?,[EW]\d+(?:\.\d+)?(?:,Z\d+)?)\]/
+const coordFirstGoogleMapRegExp = /\[([NS]\d+(?:\.\d+)?,[EW]\d+(?:\.\d+)?(?:,Z\d+)?)(?:\s+([^\]]*[^\s]))?\]/
 
 interface Coordinate {
   latitude: number
@@ -29,10 +29,7 @@ export interface GoogleMapNode {
 }
 
 const createGoogleMapNode: NodeCreator<GoogleMapNode> = target => {
-  const match =
-    target.match(/^\[([^\]]*[^\s])\s+([NS]\d+(?:\.\d+)?,[EW]\d+(?:\.\d+)?(?:,Z\d+)?)\]$/) ??
-    target.match(/^\[([NS]\d+(?:\.\d+)?,[EW]\d+(?:\.\d+)?(?:,Z\d+)?)(?:\s+([^\]]*[^\s]))?\]$/)
-
+  const match = target.match(placeFirstGoogleMapRegExp) ?? target.match(coordFirstGoogleMapRegExp)
   if (match === null) return []
 
   const isCoordFirst = target.startsWith('[N') || target.startsWith('[S')

--- a/src/block/node/HashTagNode.ts
+++ b/src/block/node/HashTagNode.ts
@@ -2,7 +2,7 @@ import { createNodeParser } from './creator'
 
 import type { NodeCreator } from './creator'
 
-const hashTagRegExp = /^(.*? )?(#\S+)(.*)$/
+const hashTagRegExp = /(?<=^| )#\S+/
 
 export interface HashTagNode {
   type: 'hashTag'

--- a/src/block/node/HelpfeelNode.ts
+++ b/src/block/node/HelpfeelNode.ts
@@ -2,7 +2,7 @@ import { createNodeParser } from './creator'
 
 import type { NodeCreator } from './creator'
 
-const helpfeelRegExp = /^()(\? .+)()$/
+const helpfeelRegExp = /^\? .+$/
 
 export interface HelpfeelNode {
   type: 'helpfeel'

--- a/src/block/node/IconNode.ts
+++ b/src/block/node/IconNode.ts
@@ -3,7 +3,7 @@ import { createNodeParser } from './creator'
 import type { NodeCreator } from './creator'
 import type { StrongIconNode } from './StrongIconNode'
 
-const iconRegExp = /^(.*?)(\[[^[\]]*\.icon(?:\*[1-9]\d*)?\])(.*)$/
+const iconRegExp = /\[[^[\]]*\.icon(?:\*[1-9]\d*)?\]/
 
 export interface IconNode {
   type: 'icon'

--- a/src/block/node/ImageNode.ts
+++ b/src/block/node/ImageNode.ts
@@ -2,10 +2,10 @@ import { createNodeParser } from './creator'
 
 import type { NodeCreator } from './creator'
 
-const srcFirstStrongImageRegExp = /^(.*?)(\[https?:\/\/[^\s\]]+\.(?:png|jpe?g|gif|svg)(?:\?[^\]\s]+)?(?:\s+https?:\/\/[^\s\]]+)?\])(.*)$/i
-const linkFirstStrongImageRegExp = /^(.*?)(\[https?:\/\/[^\s\]]+\s+https?:\/\/[^\s\]]+\.(?:png|jpe?g|gif|svg)(?:\?[^\]\s]+)?\])(.*)$/i
-const srcFirststrongGyazoImageRegExp = /^(.*?)(\[https?:\/\/(?:[0-9a-z-]+\.)?gyazo\.com\/[0-9a-f]{32}(?:\/raw)?(?:\s+https?:\/\/[^\s\]]+)?\])(.*)$/
-const linkFirststrongGyazoImageRegExp = /^(.*?)(\[https?:\/\/[^\s\]]+\s+https?:\/\/(?:[0-9a-z-]+\.)?gyazo\.com\/[0-9a-f]{32}(?:\/raw)?\])(.*)$/
+const srcFirstStrongImageRegExp = /\[https?:\/\/[^\s\]]+\.(?:png|jpe?g|gif|svg)(?:\?[^\]\s]+)?(?:\s+https?:\/\/[^\s\]]+)?\]/i
+const linkFirstStrongImageRegExp = /\[https?:\/\/[^\s\]]+\s+https?:\/\/[^\s\]]+\.(?:png|jpe?g|gif|svg)(?:\?[^\]\s]+)?\]/i
+const srcFirststrongGyazoImageRegExp = /\[https?:\/\/(?:[0-9a-z-]+\.)?gyazo\.com\/[0-9a-f]{32}(?:\/raw)?(?:\s+https?:\/\/[^\s\]]+)?\]/
+const linkFirststrongGyazoImageRegExp = /\[https?:\/\/[^\s\]]+\s+https?:\/\/(?:[0-9a-z-]+\.)?gyazo\.com\/[0-9a-f]{32}(?:\/raw)?\]/
 
 const isImageUrl = (text: string): boolean =>
   /^https?:\/\/[^\s\]]+\.(png|jpe?g|gif|svg)(\?[^\]\s]+)?$/i.test(text) || isGyazoImageUrl(text)

--- a/src/block/node/InternalLinkNode.ts
+++ b/src/block/node/InternalLinkNode.ts
@@ -2,7 +2,7 @@ import { createNodeParser } from './creator'
 
 import type { NodeCreator } from './creator'
 
-const internalLinkRegExp = /^(.*?)(\[\/?[^[\]]+\])(.*)$/
+const internalLinkRegExp = /\[\/?[^[\]]+\]/
 
 export interface InternalLinkNode {
   type: 'link'

--- a/src/block/node/QuoteNode.ts
+++ b/src/block/node/QuoteNode.ts
@@ -4,7 +4,7 @@ import { createNodeParser } from './creator'
 import type { LineNode } from '.'
 import type { NodeCreator } from './creator'
 
-const quoteRegExp = /^()(>.*)()$/
+const quoteRegExp = /^>.*$/
 
 export interface QuoteNode {
   type: 'quote'

--- a/src/block/node/StrongIconNode.ts
+++ b/src/block/node/StrongIconNode.ts
@@ -3,7 +3,7 @@ import { generateIconNodeCreator } from './IconNode'
 
 import type { NodeCreator } from './creator'
 
-const strongIconRegExp = /^(.*?)(\[\[[^[\]]*\.icon(?:\*\d+)?\]\])(.*)$/
+const strongIconRegExp = /\[\[[^[\]]*\.icon(?:\*\d+)?\]\]/
 
 export interface StrongIconNode {
   type: 'strongIcon'

--- a/src/block/node/StrongImageNode.ts
+++ b/src/block/node/StrongImageNode.ts
@@ -2,8 +2,8 @@ import { createNodeParser } from './creator'
 
 import type { NodeCreator } from './creator'
 
-const strongImageRegExp = /^(.*?)(\[\[https?:\/\/[^\s\]]+\.(?:png|jpe?g|gif|svg)\]\])(.*)$/i
-const strongGyazoImageRegExp = /^(.*?)(\[\[https?:\/\/(?:[0-9a-z-]+\.)?gyazo\.com\/[0-9a-f]{32}\]\])(.*)$/
+const strongImageRegExp = /\[\[https?:\/\/[^\s\]]+\.(?:png|jpe?g|gif|svg)\]\]/i
+const strongGyazoImageRegExp = /\[\[https?:\/\/(?:[0-9a-z-]+\.)?gyazo\.com\/[0-9a-f]{32}\]\]/
 
 export interface StrongImageNode {
   type: 'strongImage'

--- a/src/block/node/StrongNode.ts
+++ b/src/block/node/StrongNode.ts
@@ -3,7 +3,7 @@ import { createNodeParser } from './creator'
 import { convertToLineNodes, LineNode } from '.'
 import type { NodeCreator } from './creator'
 
-const strongRegExp = /^(.*?)(\[\[.+?[\]]*\]\])(.*)$/
+const strongRegExp = /\[\[.+?[\]]*\]\]/
 
 export interface StrongNode {
   type: 'strong'

--- a/src/block/node/creator.ts
+++ b/src/block/node/creator.ts
@@ -18,10 +18,13 @@ export const createNodeParser: NodeParserCreator<LineNode> = (
     if (!parseOnQuoted && opts.quoted) return next?.() ?? []
 
     for (const pattern of patterns) {
-      const match = text.match(pattern)
+      const match = pattern.exec(text)
       if (match === null) continue
-      const [, left, target, right] = match
-      const node = nodeCreator(target, opts)
+
+      const left = text.substring(0, match.index)
+      const right = text.substring(match.index + match[0].length)
+
+      const node = nodeCreator(match[0], opts)
       return [
         ...convertToLineNodes(left, opts),
         ...(Array.isArray(node) ? node : [node]),

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -20,6 +20,6 @@ export const parse = (input: string, { hasTitle = true }: Partial<ParserOption> 
 }
 
 export const getTitle = (input: string): string => {
-  const match = input.match(/^\s*(\S.*)\s*$/m)
-  return match !== null ? match[1].trim() : 'Untitled'
+  const match = /^\s*\S.*\s*$/m.exec(input)
+  return match !== null ? match[0].trim() : 'Untitled'
 }


### PR DESCRIPTION
## Proposed Changes

- Use [`RegExp.prototype.exec`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) instead of [`String.prototype.match`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match)
