### PR TITLE
Chore(ts-jest): use tsconfig instead of tsConfig

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.json'
+      tsconfig: 'tsconfig.json'
     }
   },
   collectCoverageFrom: ['src/**/*.ts'],


### PR DESCRIPTION
## Proposed Changes

- Use `tsconfig` instead of `tsConfig` in `jest.config.js`
	- Deprecations of [ts-jest@26.4.2](https://github.com/kulshekhar/ts-jest/blob/master/CHANGELOG.md#deprecations)
	- > ts-jest[config] (WARN) The option `tsConfig` is deprecated and will be removed in ts-jest 27, use `tsconfig` instead
