### PR TITLE
Fix(DecorationNode): improve Inefficient regular expression

### DIFF
--- a/src/block/node/DecorationNode.ts
+++ b/src/block/node/DecorationNode.ts
@@ -4,7 +4,7 @@ import { convertToNodes } from '.'
 import type { DecorationNode } from './type'
 import type { NodeCreator } from './creator'
 
-const decorationRegExp = /\[[!"#%&'()*+,-./{|}<>_~]+ (?:\[[^\]]+\]|[^\]])+\]/
+const decorationRegExp = /\[[!"#%&'()*+,-./{|}<>_~]+ (?:\[[^[\]]+\]|[^\]])+\]/
 
 type DecorationChar =
   | '*'

--- a/tests/line/__snapshots__/decoration.test.ts.snap
+++ b/tests/line/__snapshots__/decoration.test.ts.snap
@@ -59,6 +59,59 @@ Array [
 ]
 `;
 
+exports[`decoration Decoration with many [ and link: toMatchSnapshotWhenParsing 1`] = `
+Array [
+  Object {
+    "indent": 0,
+    "nodes": Array [
+      Object {
+        "raw": "[! ",
+        "text": "[! ",
+        "type": "plain",
+      },
+      Object {
+        "nodes": Array [
+          Object {
+            "raw": "[[[[a",
+            "text": "[[[[a",
+            "type": "plain",
+          },
+        ],
+        "raw": "[[[[[[a]]",
+        "type": "strong",
+      },
+    ],
+    "type": "line",
+  },
+]
+`;
+
+exports[`decoration Decoration with many [: toMatchSnapshotWhenParsing 1`] = `
+Array [
+  Object {
+    "indent": 0,
+    "nodes": Array [
+      Object {
+        "decos": Array [
+          "!",
+        ],
+        "nodes": Array [
+          Object {
+            "raw": "[[[[[[a",
+            "text": "[[[[[[a",
+            "type": "plain",
+          },
+        ],
+        "raw": "[! [[[[[[a]",
+        "rawDecos": "!",
+        "type": "decoration",
+      },
+    ],
+    "type": "line",
+  },
+]
+`;
+
 exports[`decoration Simple decoration: toMatchSnapshotWhenParsing 1`] = `
 Array [
   Object {

--- a/tests/line/decoration.test.ts
+++ b/tests/line/decoration.test.ts
@@ -73,4 +73,12 @@ describe('decoration', () => {
       hasTitle: false
     })
   })
+
+  it('Decoration with many [', () => {
+    expect('[! [[[[[[a]').toMatchSnapshotWhenParsing({ hasTitle: false })
+  })
+
+  it('Decoration with many [ and link', () => {
+    expect('[! [[[[[[a]]').toMatchSnapshotWhenParsing({ hasTitle: false })
+  })
 })


### PR DESCRIPTION
## Proposed Changes

-  [Regular Expression Denial-of-Service](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS) Attack flaw has found by CodeQL
	- https://github.com/progfay/scrapbox-parser/security/code-scanning/1?query=ref%3Arefs%2Fpull%2F518%2Fhead

### Before

```js
const decorationRegExp = /\[[!"#%&'()*+,-./{|}<>_~]+ (?:\[[^\]]+\]|[^\]])+\]/
`[! ${'['.repeat(30000)}z`.match(decorationRegExp) // ReDoS!!!
```

### After

```diff
- const decorationRegExp = /\[[!"#%&'()*+,-./{|}<>_~]+ (?:\[[^\]]+\]|[^\]])+\]/
+ const decorationRegExp = /\[[!"#%&'()*+,-./{|}<>_~]+ (?:\[[^[\]]+\]|[^\]])+\]/
```

`/\[[^[\]]+\]/` RegExp fail matching for `[[` with no back tracking.
