### PR TITLE
Fix(StrongNode): fix Inefficient regular expression

### DIFF
--- a/src/block/node/StrongNode.ts
+++ b/src/block/node/StrongNode.ts
@@ -4,7 +4,7 @@ import { convertToNodes } from '.'
 import type { StrongNode } from './type'
 import type { NodeCreator } from './creator'
 
-const strongRegExp = /\[\[.+?[\]]*\]\]/
+const strongRegExp = /\[\[(?:[^[]|\[[^[]).*?\]*\]\]/
 
 const createStrongNode: NodeCreator<StrongNode> = (raw, opts) => ({
   type: 'strong',


### PR DESCRIPTION
## Proposed Changes

- Avoid inefficient regular expression on matching `StrongNode` .

## PoC

```js
/\[\[.+?[\]]*\]\]/.exec(`${'['.repeat(30000)}z`) // ReDoS!!!
```
