### PR TITLE
refactor(DecorationNode): escape hyphen in RegExp

### DIFF
--- a/src/block/node/DecorationNode.ts
+++ b/src/block/node/DecorationNode.ts
@@ -4,7 +4,7 @@ import { convertToNodes } from '.'
 import type { DecorationNode } from './type'
 import type { NodeCreator } from './creator'
 
-const decorationRegExp = /\[[!"#%&'()*+,-./{|}<>_~]+ (?:\[[^[\]]+\]|[^\]])+\]/
+const decorationRegExp = /\[[!"#%&'()*+,\-./{|}<>_~]+ (?:\[[^[\]]+\]|[^\]])+\]/
 
 type DecorationChar =
   | '*'


### PR DESCRIPTION
## Proposed Changes

- Change `[,-.]` to `[,\-.]` in `decorationRegExp`
- Reported by @yuta0801 
	- Ref. https://twitter.com/yuta0381/status/1368651487841198081
