### PR TITLE
Fix(url): match url with ahead non-space character

### DIFF
--- a/src/block/node/ExternalLinkNode.ts
+++ b/src/block/node/ExternalLinkNode.ts
@@ -2,9 +2,10 @@ import type { NodeCreator } from './creator'
 import { createNodeParser } from './creator'
 import type { LinkNode } from './type'
 
-const hrefFirstUrlRegExp = /\[https?:\/\/[^\s\]]+(?:\s+[^[\]]*[^\s])?\]/
+const hrefFirstUrlRegExp = /\[https?:\/\/[^\s\]]+\s+[^\]]*[^\s]\]/
 const contentFirstUrlRegExp = /\[[^[\]]*[^\s]\s+https?:\/\/[^\s\]]+\]/
-const httpRegExp = /(?<=^| )https?:\/\/[^[\s\]]+/
+const bracketedUrlRegExp = /\[https?:\/\/[^\s\]]+\]/
+const httpRegExp = /https?:\/\/[^\s]+/
 
 const createExternalLinkNode: NodeCreator<LinkNode> = raw => {
   const inner = raw.startsWith('[') && raw.endsWith(']') ? raw.substring(1, raw.length - 1) : raw
@@ -29,5 +30,5 @@ const createExternalLinkNode: NodeCreator<LinkNode> = raw => {
 export const ExternalLinkNodeParser = createNodeParser(createExternalLinkNode, {
   parseOnNested: true,
   parseOnQuoted: true,
-  patterns: [hrefFirstUrlRegExp, contentFirstUrlRegExp, httpRegExp]
+  patterns: [hrefFirstUrlRegExp, contentFirstUrlRegExp, bracketedUrlRegExp, httpRegExp]
 })

--- a/tests/line/__snapshots__/link.test.ts.snap
+++ b/tests/line/__snapshots__/link.test.ts.snap
@@ -111,6 +111,22 @@ Array [
 ]
 `;
 
+exports[`link Simple absolute link with ahead non-space character: toMatchSnapshotWhenParsing 1`] = `
+Array [
+  Object {
+    "indent": 0,
+    "nodes": Array [
+      Object {
+        "raw": "ahttps://example.com/",
+        "text": "ahttps://example.com/",
+        "type": "plain",
+      },
+    ],
+    "type": "line",
+  },
+]
+`;
+
 exports[`link Simple absolute link with bracket: toMatchSnapshotWhenParsing 1`] = `
 Array [
   Object {

--- a/tests/line/__snapshots__/link.test.ts.snap
+++ b/tests/line/__snapshots__/link.test.ts.snap
@@ -117,9 +117,16 @@ Array [
     "indent": 0,
     "nodes": Array [
       Object {
-        "raw": "ahttps://example.com/",
-        "text": "ahttps://example.com/",
+        "raw": "a",
+        "text": "a",
         "type": "plain",
+      },
+      Object {
+        "content": "",
+        "href": "https://example.com/",
+        "pathType": "absolute",
+        "raw": "https://example.com/",
+        "type": "link",
       },
     ],
     "type": "line",

--- a/tests/line/link.test.ts
+++ b/tests/line/link.test.ts
@@ -5,6 +5,12 @@ describe('link', () => {
     })
   })
 
+  it('Simple absolute link with ahead non-space character', () => {
+    expect('ahttps://example.com/').toMatchSnapshotWhenParsing({
+      hasTitle: false
+    })
+  })
+
   it('Simple absolute link with bracket', () => {
     expect('[https://example.com/]').toMatchSnapshotWhenParsing({
       hasTitle: false


### PR DESCRIPTION
## Proposed Changes

- Fix wrong behavior of URL text parsing
- Behavior when parsing below text:

```
ahttps://example.com/
```

## Expect

```
Array [
	Object {
		"indent": 0,
		"nodes": Array [
			Object {
				"raw": "a",
				"text": "a",
				"type": "plain",
			},
			Object {
				"content": "",
				"href": "https://example.com/",
				"pathType": "absolute",
				"raw": "https://example.com/",
				"type": "link",
			},
		],
		"type": "line",
	},
]
```

## Actual

```
Array [
	Object {
		"indent": 0,
		"nodes": Array [
			Object {
				"raw": "ahttps://example.com/",
				"text": "ahttps://example.com/",
				"type": "plain",
			},
		],
		"type": "line",
	},
]
```
