### PR TITLE
Chore: set exports field for package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,12 @@
   "module": "./esm/index.js",
   "types": "./lib/index.d.ts",
   "unpkg": "./umd/scrapbox-parser.js",
+  "exports": {
+    "import": "./esm/index.js",
+    "require": "./lib/index.js",
+    "node": "./esm/index.js",
+    "default": "./lib/index.js"
+  },
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm && npm run build:umd",
     "build:cjs": "tsc -p ./tsconfig.cjs.json",


### PR DESCRIPTION
## Proposed Changes

- Set [`exports`](https://nodejs.org/api/packages.html#packages_exports) field for `package.json`
