### PR TITLE
Feat(parser): add a file extention property

### DIFF
--- a/src/block/CodeBlock.ts
+++ b/src/block/CodeBlock.ts
@@ -9,6 +9,7 @@ export interface CodeBlock {
   indent: number
   type: 'codeBlock'
   fileName: string
+  lang: string
   content: string
 }
 
@@ -17,12 +18,14 @@ export const convertToCodeBlock = (pack: CodeBlockPack): CodeBlock => {
     rows: [head, ...body]
   } = pack
   const { indent = 0, text = '' } = head ?? {}
-  const fileName: string = text.replace(/^\s*code:/, '')
+  const fileName: string = text.replace(/^\s*code:/, '').replace(/\([^()]+\)$/, '')
+  const lang: string = text.match(/\(([^()]+)\)$/)?.[1] ?? fileName.split('.').pop() ?? fileName
 
   return {
     indent,
     type: 'codeBlock',
     fileName,
+    lang,
     content: body.map((row: Row): string => row.text.substring(indent + 1)).join('\n')
   }
 }

--- a/tests/codeBlock/__snapshots__/index.test.ts.snap
+++ b/tests/codeBlock/__snapshots__/index.test.ts.snap
@@ -10,6 +10,7 @@ Array [
 }",
     "fileName": "hello.js",
     "indent": 1,
+    "lang": "js",
     "type": "codeBlock",
   },
 ]
@@ -36,6 +37,7 @@ Array [
 }",
     "fileName": "hello.js",
     "indent": 1,
+    "lang": "js",
     "type": "codeBlock",
   },
   Object {
@@ -62,6 +64,7 @@ Array [
 }",
     "fileName": "hello.js",
     "indent": 0,
+    "lang": "js",
     "type": "codeBlock",
   },
   Object {
@@ -72,6 +75,7 @@ Array [
 }",
     "fileName": "hello.js",
     "indent": 0,
+    "lang": "js",
     "type": "codeBlock",
   },
 ]
@@ -87,6 +91,23 @@ Array [
 }",
     "fileName": "hello.js",
     "indent": 0,
+    "lang": "js",
+    "type": "codeBlock",
+  },
+]
+`;
+
+exports[`Code Block Code block with parentheses: toMatchSnapshotWhenParsing 1`] = `
+Array [
+  Object {
+    "content": "export default function () {
+  alert(document.location.href)
+  console.log(\\"hello\\")
+  // You can also write comments!
+}",
+    "fileName": "hello.mjs",
+    "indent": 0,
+    "lang": "js",
     "type": "codeBlock",
   },
 ]

--- a/tests/codeBlock/index.test.ts
+++ b/tests/codeBlock/index.test.ts
@@ -42,4 +42,13 @@ code:hello.js
    // You can also write comments!
  }`).toMatchSnapshotWhenParsing({ hasTitle: false })
   })
+
+  it('Code block with parentheses', () => {
+    expect(`code:hello.mjs(js)
+ export default function () {
+   alert(document.location.href)
+   console.log("hello")
+   // You can also write comments!
+ }`).toMatchSnapshotWhenParsing({ hasTitle: false })
+  })
 })

--- a/tests/page/__snapshots__/index.test.ts.snap
+++ b/tests/page/__snapshots__/index.test.ts.snap
@@ -946,6 +946,7 @@ Array [
 }",
     "fileName": "hello.js",
     "indent": 1,
+    "lang": "js",
     "type": "codeBlock",
   },
   Object {


### PR DESCRIPTION
## Proposed Changes

- add the property `lang` in `CodeBlock`
- enable to parse filenames like `hello.ts(js)`
