### PR TITLE
add number list node

### DIFF
--- a/src/block/node/NumberListNode.ts
+++ b/src/block/node/NumberListNode.ts
@@ -1,0 +1,37 @@
+import { convertToNodes } from ".";
+import { createNodeParser } from "./creator";
+import { createPlainNode } from "./PlainNode";
+
+import type { NumberListNode, PlainNode } from "./type";
+import type { NodeCreator } from "./creator";
+
+const numberListRegExp = /^[0-9]+\. .*$/;
+
+const createNumberListNode: NodeCreator<NumberListNode | PlainNode> = (
+  raw,
+  opts
+) => {
+  if (opts.context === "table") {
+    return createPlainNode(raw, opts);
+  }
+
+  const separatorIndex = raw.indexOf(" ");
+  const rawNumber = raw.substring(0, separatorIndex - 1);
+  const number = parseInt(rawNumber, 10);
+  const text = raw.substring(separatorIndex + 1, raw.length);
+  return [
+    {
+      type: "numberList",
+      raw,
+      rawNumber,
+      number,
+      nodes: convertToNodes(text, { ...opts, nested: true }),
+    },
+  ];
+};
+
+export const NumberListNodeParser = createNodeParser(createNumberListNode, {
+  parseOnNested: false,
+  parseOnQuoted: false,
+  patterns: [numberListRegExp],
+});

--- a/src/block/node/index.ts
+++ b/src/block/node/index.ts
@@ -14,6 +14,7 @@ import { GoogleMapNodeParser } from "./GoogleMapNode";
 import { InternalLinkNodeParser } from "./InternalLinkNode";
 import { IconNodeParser } from "./IconNode";
 import { HashTagNodeParser } from "./HashTagNode";
+import { NumberListNodeParser } from "./NumberListNode";
 import { PlainNodeParser } from "./PlainNode";
 
 import type { Node } from "./type";
@@ -62,5 +63,6 @@ export const convertToNodes = combineNodeParsers(
   IconNodeParser,
   GoogleMapNodeParser,
   InternalLinkNodeParser,
-  HashTagNodeParser
+  HashTagNodeParser,
+  NumberListNodeParser
 );

--- a/src/block/node/type.ts
+++ b/src/block/node/type.ts
@@ -91,6 +91,13 @@ export interface HashTagNode extends BaseNode {
   href: string;
 }
 
+export interface NumberListNode extends BaseNode {
+  type: "numberList";
+  rawNumber: string;
+  number: number;
+  nodes: Node[];
+}
+
 export interface PlainNode extends BaseNode {
   type: "plain";
   text: string;
@@ -112,4 +119,5 @@ export type Node =
   | GoogleMapNode
   | IconNode
   | HashTagNode
+  | NumberListNode
   | PlainNode;

--- a/tests/line/__snapshots__/numberList.test.ts.snap
+++ b/tests/line/__snapshots__/numberList.test.ts.snap
@@ -32,6 +32,24 @@ Array [
 ]
 `;
 
+exports[`numberList Minimum numberList 1`] = `
+Array [
+  Object {
+    "indent": 0,
+    "nodes": Array [
+      Object {
+        "nodes": Array [],
+        "number": 1,
+        "raw": "1. ",
+        "rawNumber": "1",
+        "type": "numberList",
+      },
+    ],
+    "type": "line",
+  },
+]
+`;
+
 exports[`numberList No head 1. is not numberList 1`] = `
 Array [
   Object {

--- a/tests/line/__snapshots__/numberList.test.ts.snap
+++ b/tests/line/__snapshots__/numberList.test.ts.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`numberList 1. with no space is not numberList 1`] = `
+Array [
+  Object {
+    "indent": 0,
+    "nodes": Array [
+      Object {
+        "raw": "1.",
+        "text": "1.",
+        "type": "plain",
+      },
+    ],
+    "type": "line",
+  },
+]
+`;
+
+exports[`numberList 1. with no space is not numberList 2`] = `
+Array [
+  Object {
+    "indent": 0,
+    "nodes": Array [
+      Object {
+        "raw": "1.not numberList",
+        "text": "1.not numberList",
+        "type": "plain",
+      },
+    ],
+    "type": "line",
+  },
+]
+`;
+
+exports[`numberList No head 1. is not numberList 1`] = `
+Array [
+  Object {
+    "indent": 0,
+    "nodes": Array [
+      Object {
+        "raw": "a 1. not numberList",
+        "text": "a 1. not numberList",
+        "type": "plain",
+      },
+    ],
+    "type": "line",
+  },
+]
+`;
+
+exports[`numberList Quoted 1. is not numberList 1`] = `
+Array [
+  Object {
+    "indent": 0,
+    "nodes": Array [
+      Object {
+        "nodes": Array [
+          Object {
+            "raw": " 1. Quoted",
+            "text": " 1. Quoted",
+            "type": "plain",
+          },
+        ],
+        "raw": "> 1. Quoted",
+        "type": "quote",
+      },
+    ],
+    "type": "line",
+  },
+]
+`;
+
+exports[`numberList Simple numberList 1`] = `
+Array [
+  Object {
+    "indent": 0,
+    "nodes": Array [
+      Object {
+        "nodes": Array [
+          Object {
+            "raw": "Simple numberList",
+            "text": "Simple numberList",
+            "type": "plain",
+          },
+        ],
+        "number": 1,
+        "raw": "1. Simple numberList",
+        "rawNumber": "1",
+        "type": "numberList",
+      },
+    ],
+    "type": "line",
+  },
+]
+`;

--- a/tests/line/numberList.test.ts
+++ b/tests/line/numberList.test.ts
@@ -1,4 +1,10 @@
 describe("numberList", () => {
+  it("Minimum numberList", () => {
+    expect("1. ").toMatchSnapshotWhenParsing({
+      hasTitle: false,
+    });
+  });
+
   it("Simple numberList", () => {
     expect("1. Simple numberList").toMatchSnapshotWhenParsing({
       hasTitle: false,

--- a/tests/line/numberList.test.ts
+++ b/tests/line/numberList.test.ts
@@ -1,0 +1,26 @@
+describe("numberList", () => {
+  it("Simple numberList", () => {
+    expect("1. Simple numberList").toMatchSnapshotWhenParsing({
+      hasTitle: false,
+    });
+  });
+
+  it("1. with no space is not numberList", () => {
+    expect("1.").toMatchSnapshotWhenParsing({
+      hasTitle: false,
+    });
+    expect("1.not numberList").toMatchSnapshotWhenParsing({
+      hasTitle: false,
+    });
+  });
+
+  it("No head 1. is not numberList", () => {
+    expect("a 1. not numberList").toMatchSnapshotWhenParsing({
+      hasTitle: false,
+    });
+  });
+
+  it("Quoted 1. is not numberList", () => {
+    expect("> 1. Quoted").toMatchSnapshotWhenParsing({ hasTitle: false });
+  });
+});


### PR DESCRIPTION
## Proposed Changes

- number list node
  - A line with `1. ` treated as `.number-list` class in Scrapbox https://scrapbox.io/scrapboxlab/番号付きリスト
  - I added `NumberListNode` as a parent node of the nodes of the rest text
    - e.g. `1. [* hoge]` becomes `Line > NumberListNode > DecorationNode > PlainNode`

### 🤔 

- Should number list be new `Block` (not `Node` ) ?
- I tried to run tests ( `npm run test:update` ) but they failed on all tests as follows:
  - Would you please run them instead of me?

```
 FAIL  tests/line/strongIcon.test.ts
  ● Test suite failed to run

    tests/jest-setup.ts:29:47 - error TS2554: Expected 2 arguments, but got 3.

    29     return toMatchSnapshot.call(this, blocks, "toMatchSnapshotWhenParsing");
                                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
