### PR TITLE
fix(test): include extended matchers typing

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -67,5 +67,5 @@
     "skipLibCheck": true,                     /* Skip type checking of declaration files. */
     "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/jest-setup.ts"]
 }


### PR DESCRIPTION
## Proposed Changes

- The below errors ware occurred in `expect.toMatchSnapshotWhenParsing`.
  - > Property `'toMatchSnapshotWhenParsing'` does not exist on type `'JestMatchers<string>'`.
- To fix this error, I added `tests/jest-setup.ts` to `compilerOptions.includes` in `tsconfig.json`.
  - ref. https://github.com/testing-library/jest-dom#with-typescript
