### PR TITLE
fix(build): fix error in `npm run build`

### DIFF
--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,2 @@
+/jest-setup.*
+!/jest-setup.ts

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -5,5 +5,6 @@
     "rootDir": "./src",
     "outDir": "./lib",
     "tsBuildInfoFile": "./.cjs.tsbuildinfo"
-  }
+  },
+  "exclude": ["tests/jest-setup.ts"]
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -5,5 +5,6 @@
     "rootDir": "./src",
     "outDir": "./esm",
     "tsBuildInfoFile": "./.esm.tsbuildinfo"
-  }
+  },
+  "exclude": ["tests/jest-setup.ts"]
 }

--- a/tsconfig.umd.json
+++ b/tsconfig.umd.json
@@ -6,5 +6,6 @@
     "composite": false,
     "declaration": false,
     "declarationMap": false
-  }
+  },
+  "exclude": ["tests/jest-setup.ts"]
 }


### PR DESCRIPTION
## Proposed Changes

- Fix below errors

```console
npm ERR! error TS6059: File 'progfay/scrapbox-parser/tests/jest-setup.ts' is not under 'rootDir' 'progfay/scrapbox-parser/src'. 'rootDir' is expected to contain all source files.
npm ERR!   The file is in the program because:
npm ERR!     Matched by include pattern 'tests/jest-setup.ts' in 'tsconfig.esm.json'
npm ERR! error TS6059: File 'progfay/scrapbox-parser/tests/jest-setup.ts' is not under 'rootDir' 'progfay/scrapbox-parser/src'. 'rootDir' is expected to contain all source files.
npm ERR!   The file is in the program because:
npm ERR!     Matched by include pattern 'tests/jest-setup.ts' in 'tsconfig.cjs.json'
npm ERR! ERROR: "build:esm" exited with 2.
```
