### PR TITLE
change `new_version` default choice

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@ on:
         required: true
         type: choice
         options:
-        - major
-        - minor
         - patch
+        - minor
+        - major
 
 jobs:
   publish:


### PR DESCRIPTION
## Proposed Changes

- change the default choice of `new_version` on "publish" GHA
  - Before: "major"
  - After: "patch"
- To reduce the impact of human error
