### PR TITLE
publish package for npm with OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write # The OIDC ID token is used for authentication with JSR.
+      id-token: write # The OIDC ID token is used for authentication with npm / JSR.
     steps:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-node@v4.4.0
         with:
+          node-version: '20'
           registry-url: 'https://registry.npmjs.org'
       - name: Publish package
         run: |
@@ -46,4 +47,3 @@ jobs:
           git push
         env:
           NEW_VERSION: ${{ inputs.new_version }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Proposed Changes

- https://docs.npmjs.com/trusted-publishers
- https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
